### PR TITLE
Fix race condition when stopping before spinner fully built

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -147,10 +147,10 @@ func (s *Spinner) StartWithSpeed(message string, speed time.Duration) error {
 
 	s.message = message
 	s.createFrames()
+	s.ticker = time.NewTicker(speed)
 	// Start the animation in background
 	go func() {
 		s.running = true
-		s.ticker = time.NewTicker(speed)
 
 		for range s.ticker.C {
 			s.Render()


### PR DESCRIPTION
We're running into a race condition that is fairly repeatable:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1072502]

goroutine 1 [running]:
time.(*Ticker).Stop(0x0)
    /usr/local/go/src/time/tick.go:46 +0x22
github.com/phase2/rig/vendor/github.com/slok/gospinner.(*Spinner).Stop(0xc4200a83c0, 0x0, 0x0)
    /go/src/github.com/phase2/rig/vendor/github.com/slok/gospinner/spinner.go:197 +0xe6
github.com/phase2/rig/vendor/github.com/slok/gospinner.(*Spinner).FinishWithMessage(0xc4200a83c0, 0xc420089b60, 0xc, 0xc420086c60, 0x23, 0x3, 0xc4201336e0)
    /go/src/github.com/phase2/rig/vendor/github.com/slok/gospinner/spinner.go:240 +0x40
github.com/phase2/rig/vendor/github.com/slok/gospinner.(*Spinner).FinishWithSymbol(0xc4200a83c0, 0xc420089b60, 0xc, 0x0, 0x0)
    /go/src/github.com/phase2/rig/vendor/github.com/slok/gospinner/spinner.go:235 +0x51
github.com/phase2/rig/vendor/github.com/slok/gospinner.(*Spinner).Warn(0xc4200a83c0, 0xc420086c60, 0x23)
    /go/src/github.com/phase2/rig/vendor/github.com/slok/gospinner/spinner.go:220 +0x8a
```

I think moving the creation of the timer out of the goroutine will solve the problem.

https://github.com/phase2/rig/issues/160
